### PR TITLE
RTSP Video Streaming

### DIFF
--- a/samples/Samples.h
+++ b/samples/Samples.h
@@ -76,6 +76,8 @@ typedef struct {
     volatile ATOMIC_BOOL recreateSignalingClient;
     volatile ATOMIC_BOOL connected;
     BOOL useTestSrc;
+    PCHAR videoUrl;
+    PCHAR audioUrl;
     ChannelInfo channelInfo;
     PCHAR pCaCertPath;
     PAwsCredentialProvider pCredentialProvider;


### PR DESCRIPTION
## What I did

Modified the interface of command line tool and gstreamer command to make it consume RTSP streams.

## Sample command

```bash
mkdir -p build && cd build
cmake .. && make
./kvsWebrtcClientMasterGstSample signaling-channel-name rtsp://rtsp.stream/pattern
```

## Facing issues

### Mac

It seems working, but no video is shown in AWS Web Console. It works correctly when I use sample stream, not the actual camera stream. i.e. rtsp://rtsp.stream/pattern

Because it doesn't show any errors, it's really hard to know the root cause.

### Debian

In fact, debian has more issues than Mac. It can't publish not only IP-Camera streams but also sample public streams. i.e. rtsp://rtsp.stream/pattern

I could see the below message, but had no idea to fix it.
```
Unable to fetch request Timestamp from the hash table. No update to totalRoundTripTime (error code: 0x40100001)
```